### PR TITLE
dismiss view if dismiss is called before the view is visible

### DIFF
--- a/KVNProgress/Classes/KVNProgress.m
+++ b/KVNProgress/Classes/KVNProgress.m
@@ -1225,7 +1225,7 @@ static KVNProgressConfiguration *configuration;
 
 + (BOOL)isVisible
 {
-	return ([self sharedView].superview != nil && [self sharedView].alpha > 0.0f);
+	return [self sharedView].alpha > 0.0f;
 }
 
 #pragma mark - HitTest

--- a/KVNProgress/Classes/KVNProgress.m
+++ b/KVNProgress/Classes/KVNProgress.m
@@ -428,6 +428,10 @@ static KVNProgressConfiguration *configuration;
 + (void)dismissWithCompletion:(KVNCompletionBlock)completion
 {
 	if (![self isVisible]) {
+        if ([self sharedView].superview) {
+            [[self sharedView] cancelCircleAnimation];
+            [[self sharedView] removeFromSuperview];
+        }
 		return;
 	}
 	


### PR DESCRIPTION
If there is a race between when the progress view becomes visible and when `+dismiss` is called, the progress view shows up and can spin indefinitely because the call to dismiss it is overlooked.