### PR TITLE
import UIKit

### DIFF
--- a/KVNProgress/Classes/KVNProgressConfiguration.h
+++ b/KVNProgress/Classes/KVNProgressConfiguration.h
@@ -7,6 +7,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 typedef NS_ENUM(NSUInteger, KVNProgressBackgroundType) {
 	/** Don't allow user interactions and show a blurred background. Default value. */


### PR DESCRIPTION
Swift projects or new projects that don't contain the Prefix.pch won't import UIKit normally