### PR TITLE
Fix bundle loading issue

### DIFF
--- a/KVNProgress/Classes/KVNProgress.m
+++ b/KVNProgress/Classes/KVNProgress.m
@@ -100,7 +100,7 @@ static KVNProgressConfiguration *configuration;
 	
 	dispatch_once(&onceToken, ^{
 		UINib *nib = [UINib nibWithNibName:@"KVNProgressView"
-									bundle:nil];
+                                    bundle:[NSBundle bundleForClass:[self class]]];
 		NSArray *nibViews = [nib instantiateWithOwner:self
 											  options:0];
 		


### PR DESCRIPTION
```
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Could not load NIB in bundle: 'NSBundle </private/var/mobile/Containers/Bundle/Application/32249414-4003-4BE3-99A0-42A9954C1417/United.app> (loaded)' with name 'KVNProgressView''
*** First throw call stack:
(0x1827e659c 0x192f3c0e4 0x1827e64dc 0x1873a3448 0x10063ae04 0x100cbcdf0 0x100cbdcfc 0x10063ad68 0x10063be84 0x10063b584 0x10063b4dc 0x1000ccd3c 0x1000cc94c 0x1000cc994 0x186fafa5c 0x18704d624 0x18704cff8 0x18704cd18 0x18704cc98 0x186f95648 0x1868ed994 0x1868e8564 0x1868e8408 0x1868e7c08 0x1868e798c 0x1868e13bc 0x18279ea50 0x18279b9dc 0x18279bdbc 0x1826c90a4 0x18b86b5a4 0x186ffe3c0 0x1000e45d4 0x1000e4614 0x1935aaa08)
libc++abi.dylib: terminating with uncaught exception of type NSException
```