### PR TITLE
fix for KVNProgress not shown if NSLayoutConstraints broken before

### DIFF
--- a/KVNProgress/Classes/KVNProgress.m
+++ b/KVNProgress/Classes/KVNProgress.m
@@ -800,10 +800,16 @@ static KVNProgressConfiguration *configuration;
 
 - (void)addToView:(UIView *)superview
 {
+	superview = [UIApplication sharedApplication].keyWindow;
+	if (!superview) {
+		superview = [[UIApplication sharedApplication].windows objectAtIndex:0];
+	}
+	
 	if (self.superview) {
 		[self.superview removeConstraints:self.constraintsToSuperview];
 		[self removeFromSuperview];
 	}
+	
 	
 	[superview addSubview:self];
 	[superview bringSubviewToFront:self];


### PR DESCRIPTION
This Fix is only needed if you have the Problem of broken NSLayout before and KVN wont show. 
Shure there are several ways to get topview but this one works everytime.